### PR TITLE
Allow Functions for Loss Validation

### DIFF
--- a/explora/utils/validation.py
+++ b/explora/utils/validation.py
@@ -56,8 +56,8 @@ def valid_model(library_type, model):
         print(ErrorMessages.NOT_COMPILED.value)
         return False
     elif library_type == LibraryType.IOS.value \
-            and (model.loss != 'categorical_crossentropy'
-                or model.loss != keras.losses.categorical_crossentropy):
+            and model.loss != 'categorical_crossentropy' \
+            and model.loss != keras.losses.categorical_crossentropy:
         print(ErrorMessages.INVALID_LOSS.value)
         return False
 

--- a/explora/utils/validation.py
+++ b/explora/utils/validation.py
@@ -50,14 +50,14 @@ def valid_model(library_type, model):
         bool: True if Keras model and compiled, False otherwise.
     """
     if not isinstance(model, keras.engine.Model):
-        print(type(model))
         print(ErrorMessages.INVALID_MODEL_TYPE.value)
         return False
     elif not model.optimizer or not model.loss:
         print(ErrorMessages.NOT_COMPILED.value)
         return False
     elif library_type == LibraryType.IOS.value \
-            and model.loss != 'categorical_crossentropy':
+            and not (model.loss != 'categorical_crossentropy'
+                or model.loss != keras.losses.categorical_crossentropy):
         print(ErrorMessages.INVALID_LOSS.value)
         return False
 

--- a/explora/utils/validation.py
+++ b/explora/utils/validation.py
@@ -56,7 +56,7 @@ def valid_model(library_type, model):
         print(ErrorMessages.NOT_COMPILED.value)
         return False
     elif library_type == LibraryType.IOS.value \
-            and not (model.loss != 'categorical_crossentropy'
+            and (model.loss != 'categorical_crossentropy'
                 or model.loss != keras.losses.categorical_crossentropy):
         print(ErrorMessages.INVALID_LOSS.value)
         return False


### PR DESCRIPTION
Previously, only a string `model.loss` was allowed, when instead we should allow the original keras loss function as well.

So for example in the iOS case, `model.loss` can be `categorical_crossentropy` or `keras.losses.categorical_crossentropy`.