### PR TITLE
Add Sample Notebook for iOS Library

### DIFF
--- a/explora/ExploraSample.ipynb
+++ b/explora/ExploraSample.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import any other necessary packages here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import keras\n",
+    "from keras.models import load_model\n",
+    "from explora import start_new_session, make_data_config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_keras_base_model():\n",
+    "    \"\"\"This method creates a convolutional neural network model using Keras.\n",
+    "    url - The URL that the keras model will be saved as h5 file.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    import keras\n",
+    "    from keras.models import Sequential\n",
+    "    from keras.layers import Dense, Dropout, Flatten, Conv2D, MaxPooling2D\n",
+    "    \n",
+    "    keras.backend.clear_session()\n",
+    "    model = Sequential()\n",
+    "    model.add(Conv2D(32, kernel_size=(3, 3),\n",
+    "                     activation='relu',\n",
+    "                     input_shape=(28, 28, 1)))\n",
+    "    model.add(Conv2D(64, (3, 3), activation='relu'))\n",
+    "    model.add(MaxPooling2D(pool_size=(2, 2)))\n",
+    "    model.add(Dropout(0.25))\n",
+    "    model.add(Flatten())\n",
+    "    model.add(Dense(10, activation='relu'))\n",
+    "    model.add(Dropout(0.5))\n",
+    "    model.add(Dense(10, activation='softmax'))\n",
+    "\n",
+    "    model.compile(loss=keras.losses.categorical_crossentropy,\n",
+    "                  optimizer=keras.optimizers.SGD(lr=0.01),\n",
+    "                  metrics=['accuracy'])\n",
+    "    return model\n",
+    "\n",
+    "model = create_keras_base_model()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the repo id to the variable here:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_id = \"f93bb383416a5140c328ee1bd177eb6c\" # REPO ID HERE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the library type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library_type = \"IOS\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the hyperparameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hyperparams = {\n",
+    "    \"batch_size\": 100,\n",
+    "    \"epochs\": 5,\n",
+    "    \"shuffle\": True,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the percentage of nodes that should be averaged before moving on to the next round."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "percentage_averaged = 0.75"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the maximum amount of rounds to train for."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_rounds = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set how often checkpoints should be generated during training (once every `checkpoint_frequency` rounds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checkpoint_frequency = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Model conversion for iOS libraries requires a specific configuration based on the type of dataset. For now, only image datasets are supported, so we set the data type accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_type = \"image\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What are the different classes that the model can take?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class_labels = [str(i) for i in range(10)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What is the width and height of each image in the dataset?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "width = 28\n",
+    "height = 28"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dims = (width, height)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we must create the data config using the provided helper function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_config = make_data_config(data_type, class_labels, color_space=color_space, image_dims=dims)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now run the following line to start a new iOS session and begin training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await start_new_session(repo_id, model, hyperparams, percentage_averaged, max_rounds, library_type, checkpoint_frequency, data_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/explora/ExploraSample.ipynb
+++ b/explora/ExploraSample.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "repo_id = \"f93bb383416a5140c328ee1bd177eb6c\" # REPO ID HERE"
+    "repo_id = \"\" # REPO ID HERE"
    ]
   },
   {
@@ -286,7 +286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding a new notebook, `explora/ExploraSample.ipynb`, that currently represents a sample notebook needed to immediately start a session with clients running the iOS library (note that a repo ID still needed).