### PR TITLE
Build Docker Image in CodePipeline

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,25 @@
 version: 0.2
 
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...          
+      - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG cloud-node
+      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG      
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+
 artifacts:
   files:
     - Dockerrun.aws.json


### PR DESCRIPTION
Automatically build Docker image with current cloud node during pipeline process (so that deployment uses this updated image)

TODO: Only trigger changes for cloud node updates (might just have to separate cloud node from main repo)