### PR TITLE
Add TTL to DynamoDB

### DIFF
--- a/cloud-node/updatestore.py
+++ b/cloud-node/updatestore.py
@@ -40,7 +40,7 @@ def store_update(type, message, with_weights=True):
             "Id": str(uuid.uuid4()),
             "RepoId": state.state["repo_id"],
             "Timestamp": int(current_time.timestamp),
-            "TTL": int((current_time + timedelta(days=3)).timestamp)
+            "TTL": int((current_time + timedelta(days=3)).timestamp),
             "ContentType": type,
             "SessionId": state.state["session_id"],
             "Content": repr(message),

--- a/cloud-node/updatestore.py
+++ b/cloud-node/updatestore.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime, timedelta
 import uuid
 import os
 import boto3
@@ -34,10 +35,12 @@ def store_update(type, message, with_weights=True):
     try:
         dynamodb = boto3.resource("dynamodb", region_name="us-west-1")
         table = dynamodb.Table("UpdateStore")
+        current_time = datetime.now()
         item = {
             "Id": str(uuid.uuid4()),
             "RepoId": state.state["repo_id"],
-            "Timestamp": int(time.time()),
+            "Timestamp": int(current_time.timestamp),
+            "TTL": int((current_time + timedelta(days=3)).timestamp)
             "ContentType": type,
             "SessionId": state.state["session_id"],
             "Content": repr(message),

--- a/cloud-node/updatestore.py
+++ b/cloud-node/updatestore.py
@@ -39,8 +39,8 @@ def store_update(type, message, with_weights=True):
         item = {
             "Id": str(uuid.uuid4()),
             "RepoId": state.state["repo_id"],
-            "Timestamp": int(current_time.timestamp),
-            "TTL": int((current_time + timedelta(days=3)).timestamp),
+            "CreationTime": int(current_time.timestamp),
+            "ExpirationTime": int((current_time + timedelta(days=3)).timestamp),
             "ContentType": type,
             "SessionId": state.state["session_id"],
             "Content": repr(message),

--- a/dashboard-api/app.py
+++ b/dashboard-api/app.py
@@ -200,7 +200,7 @@ def get_logs(repo_id):
         _assert_user_can_read_repo(user_id, repo_id)
         logs = _get_logs(repo_id)
     except Exception as e:
-        return jsonify(make_error(str(e))), 400
+        return jsonify(make_error(str(e)))
     return jsonify(logs)
 
 @app.route("/coordinator/status/<repo_id>", methods=["GET"])
@@ -326,7 +326,8 @@ def _get_logs(repo_id):
     logs_table = _get_dynamodb_table("UpdateStore")
     try:
         response = logs_table.query(
-            KeyConditionExpression=Key('RepoId').eq(repo_id)
+            KeyConditionExpression=Key('RepoId').eq(repo_id) \
+                & Key('ExpirationTime').gt(int(time.time())) 
         )
         logs = response["Items"]
     except Exception as e:

--- a/dashboard-api/test.py
+++ b/dashboard-api/test.py
@@ -1,4 +1,0 @@
-from deploy import deploy_new_version
-
-result = deploy_new_version("bruh3")
-print(result)


### PR DESCRIPTION
Add TTL to DynamoDB repo log entry (set up so that DynamoDB will use it to determine whether to the entry is expired or not).