### PR TITLE
Add Default Models

### DIFF
--- a/explora/explora.py
+++ b/explora/explora.py
@@ -77,6 +77,9 @@ async def start_new_session(repo_id, hyperparameters, model_name=None, \
         dataset_id (str, optional): The dataset ID for the dataset, if
             applicable. If `library_type` is `IOS`, then this argument is 
             required since the application may have multiple datasets!
+        model_name (str): The name of the default model to train with, stored
+            in Explora already. If valid, the model path and data config
+            don't need to be specified with this argument.
 
     Examples:
         >>> start_new_session(

--- a/explora/explora.py
+++ b/explora/explora.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 tf.compat.v1.disable_v2_behavior()
 
 from utils.validation import valid_session_args, valid_image_config_args, \
-    valid_text_config_args
+    valid_text_config_args, valid_model_name
 from utils.s3_utils import upload_keras_model
 from utils.websocket_utils import websocket_connect
 from utils.enums import ErrorMessages, DataType, data_types
@@ -47,9 +47,10 @@ def make_data_config(data_type, image_labels=None, vocab_size=None, \
             "Invalid text config arguments!"
         return TextConfig(vocab_size)
 
-async def start_new_session(repo_id, model_path, hyperparameters, \
-        percentage_averaged=0.75, max_rounds=5, library_type="PYTHON", \
-        checkpoint_frequency=1, data_config=None, dataset_id=None):
+async def start_new_session(repo_id, hyperparameters, model_name=None, \
+        model_path=None, percentage_averaged=0.75, max_rounds=5, \
+        library_type="PYTHON", checkpoint_frequency=1, data_config=None, \
+        dataset_id=None):
     """
     Validate arguments and then start a new session by sending a message to
     the server with the given configuration. Designed to be called in
@@ -57,11 +58,11 @@ async def start_new_session(repo_id, model_path, hyperparameters, \
 
     Args:
         repo_id (str): The repo ID associated with the current dataset.
+        hyperparams (dict): The hyperparameters to be used during training.
+            Must include `batch_size`!
         model_path (str): The path to the initial model to train with. Must be 
             an `.mlmodel` (`MLModel`) file if the model is a text model for 
             iOS, or a `.h5` (compiled Keras model) file otherwise.
-        hyperparams (dict): The hyperparameters to be used during training.
-            Must include `batch_size`!
         percentage_averaged (float, optional): Percentage of nodes to be 
             averaged before moving on to the next round. Defaults to 0.75.
         max_rounds (int, optional): Maximum number of rounds to train for.
@@ -94,8 +95,14 @@ async def start_new_session(repo_id, model_path, hyperparameters, \
     cloud_node_host = "ws://" + repo_id + CLOUD_BASE_URL
     session_id = str(uuid.uuid4())
 
-    if not valid_session_args(repo_id, model_path, hyperparameters, \
-            percentage_averaged, max_rounds, library_type, \
+    if model_name:
+        model_path, data_config = valid_model_name(model_name, library_type, \
+            model_path)
+        if not model_path:
+            return
+
+    if not valid_session_args(repo_id, model_path, model_name, \
+            hyperparameters, percentage_averaged, max_rounds, library_type, \
             checkpoint_frequency, data_config, dataset_id):
         return
     

--- a/explora/tests/conftest.py
+++ b/explora/tests/conftest.py
@@ -6,7 +6,8 @@ import tensorflow as tf
 tf.compat.v1.disable_v2_behavior()
 
 from explora import make_data_config
-from utils.enums import LibraryType
+from utils.enums import LibraryType, ModelNames
+from utils.validation import _make_mnist_config, _make_ngram_config
 
 
 @pytest.fixture(scope="session")
@@ -26,28 +27,40 @@ def bad_dataset_id():
     return None
 
 @pytest.fixture(scope="session")
-def good_keras_model_path():
+def good_keras_path():
     return "explora/tests/artifacts/model.h5"
 
 @pytest.fixture(scope="session")
-def good_keras_ios_model_path():
+def good_ios_model_path():
     return "explora/tests/artifacts/ios_model.h5"
 
 @pytest.fixture(scope="session")
-def bad_keras_model_path():
+def bad_keras_path():
     return "explora/tests/artifacts/bad_model.h5"
 
 @pytest.fixture(scope="session")
-def bad_keras_ios_model_path():
+def bad_ios_model_path():
     return "explora/tests/artifacts/bad_ios_model.h5"
 
 @pytest.fixture(scope="session")
-def bad_keras_ios_model_2_path():
+def bad_ios_model_path_2():
     return "explora/tests/artifacts/bad_ios_model_2.h5"
 
 @pytest.fixture(scope="session")
 def good_mlmodel_path():
     return "explora/tests/artifacts/my_model.mlmodel"
+
+@pytest.fixture(scope="session")
+def good_keras_name():
+    return ModelNames.MNIST.value
+
+@pytest.fixture(scope="session")
+def good_mlmodel_name():
+    return ModelNames.NGRAM.value
+
+@pytest.fixture(scope="session")
+def bad_model_name():
+    return "bad-model-name"
 
 @pytest.fixture(scope="session")
 def good_hyperparams():
@@ -190,4 +203,11 @@ def good_text_config_args(good_vocab_size):
 def bad_text_config_args(bad_vocab_size):
     return (bad_vocab_size,) 
 
+@pytest.fixture(scope="session")
+def mnist_config():
+    return _make_mnist_config()
+
+@pytest.fixture(scope="session")
+def ngram_config():
+    return _make_ngram_config()
   

--- a/explora/tests/test_validation.py
+++ b/explora/tests/test_validation.py
@@ -7,7 +7,8 @@ from utils.validation import valid_repo_id, valid_model, \
     valid_and_prepare_hyperparameters, valid_percentage_averaged, \
     valid_max_rounds, valid_library_type, valid_dataset_id, \
     valid_checkpoint_frequency, valid_data_config, valid_image_config_args, \
-    valid_text_config_args, valid_session_args
+    valid_text_config_args, valid_session_args, valid_model_name
+from utils.enums import ModelPaths
 
 
 def test_repo_id_validation(good_repo_id, bad_repo_id):
@@ -38,34 +39,33 @@ def test_dataset_id_validation(ios, python, good_dataset_id, bad_dataset_id):
     assert not valid_dataset_id(python, good_dataset_id), \
         "This repo ID should have failed validation!"
 
-def test_keras_model_validation(good_keras_model_path, bad_keras_model_path):
+def test_keras_validation(good_keras_path, bad_keras_path):
     """
     Test that a valid Keras model passes validation and an invalid one fails 
     validation.
     """
-    assert valid_model(None, good_keras_model_path), \
+    assert valid_model(None, good_keras_path), \
         "This model path should have passed validation!"
 
-    assert not valid_model(None, bad_keras_model_path), \
+    assert not valid_model(None, bad_keras_path), \
         "This model path should have failed validation!"
 
     assert not valid_model(None, ""), \
         "This model path should have failed validation!"
 
-def test_keras_ios_model_validation(good_image_config, \
-        good_keras_ios_model_path, bad_keras_ios_model_path, \
-        bad_keras_ios_model_2_path):
+def test_ios_model_validation(good_image_config, good_ios_model_path, \
+        bad_ios_model_path, bad_ios_model_path_2):
     """
     Test that a valid Keras model for iOS passes validation and an invalid one 
     fails validation.
     """
-    assert valid_model(good_image_config, good_keras_ios_model_path), \
+    assert valid_model(good_image_config, good_ios_model_path), \
         "This model path should have passed validation!"
 
-    assert not valid_model(good_image_config, bad_keras_ios_model_path), \
+    assert not valid_model(good_image_config, bad_ios_model_path), \
         "This model path should have failed validation!"
 
-    assert not valid_model(good_image_config, bad_keras_ios_model_2_path), \
+    assert not valid_model(good_image_config, bad_ios_model_path_2), \
         "This model path should have failed validation!"
 
     assert not valid_model(good_image_config, None), \
@@ -77,6 +77,35 @@ def test_mlmodel_validation(good_text_config, good_mlmodel_path):
 
     assert not valid_model(good_text_config, None), \
         "This model path should have failed validation!"
+
+def test_model_name(python, good_keras_name, ios, mnist_config, \
+        good_mlmodel_name, ngram_config, bad_model_name, good_keras_path):
+    """
+    Test that a valid model name passes validation and an invalid one fails 
+    validation.
+    """
+    model_path, data_config = valid_model_name(good_keras_name, python, None)
+    assert model_path == ModelPaths.MNIST_PATH.value and not data_config, \
+        "This model name should have passed validation!"
+
+    model_path, data_config = valid_model_name(good_keras_name, ios, None)
+    assert model_path == ModelPaths.IOS_MNIST_PATH.value \
+            and data_config == mnist_config, \
+        "This model name should have passed validation!"
+
+    model_path, data_config = valid_model_name(good_mlmodel_name, ios, None)
+    assert model_path == ModelPaths.NGRAM_PATH.value \
+            and data_config == ngram_config, \
+        "This model name should have passed validation!"
+
+    model_path, data_config = valid_model_name(bad_model_name, python, None)
+    assert not model_path and not data_config, \
+        "This model name should have failed validation!"
+
+    model_path, data_config = valid_model_name(good_keras_name, python, \
+        good_keras_path)
+    assert not model_path and not data_config, \
+        "This model name should have failed validation!"
 
 def test_hyperparams_validation(good_hyperparams, bad_hyperparams):
     """

--- a/explora/tests/test_validation.py
+++ b/explora/tests/test_validation.py
@@ -72,6 +72,10 @@ def test_ios_model_validation(good_image_config, good_ios_model_path, \
         "This model path should have failed validation!"
 
 def test_mlmodel_validation(good_text_config, good_mlmodel_path):
+    """
+    Test that a valid MLModel for iOS passes validation and an invalid one 
+    fails validation.
+    """
     assert valid_model(good_text_config, good_mlmodel_path), \
         "This model path should have passed validation!"
 

--- a/explora/utils/data_config.py
+++ b/explora/utils/data_config.py
@@ -12,6 +12,15 @@ class DataConfig(object):
         self.class_labels = class_labels
 
     def __eq__(self, other):
+        """
+        Custom comparator for checking equality between data configs.
+        
+        Args:
+            other (DataConfig): The other data config to compare with.
+        
+        Returns:
+            bool: True if equal, False otherwise.
+        """
         return self.data_type == other.data_type \
             and self.class_labels == other.class_labels
 
@@ -45,6 +54,15 @@ class ImageConfig(DataConfig):
         self.dims = dims
 
     def __eq__(self, other):
+        """
+        Custom comparator for checking equality between image configs.
+        
+        Args:
+            other (ImageConfig): The other image config to compare with.
+        
+        Returns:
+            bool: True if equal, False otherwise.
+        """
         return super().__eq__(other) \
             and self.color_space == other.color_space \
             and self.dims == other.dims

--- a/explora/utils/data_config.py
+++ b/explora/utils/data_config.py
@@ -11,6 +11,10 @@ class DataConfig(object):
         self.data_type = data_type
         self.class_labels = class_labels
 
+    def __eq__(self, other):
+        return self.data_type == other.data_type \
+            and self.class_labels == other.class_labels
+
     def serialize(self):
         """
         Serialize the config into a dictionary.
@@ -39,6 +43,11 @@ class ImageConfig(DataConfig):
         super().__init__("image", class_labels)
         self.color_space = color_space
         self.dims = dims
+
+    def __eq__(self, other):
+        return super().__eq__(other) \
+            and self.color_space == other.color_space \
+            and self.dims == other.dims
 
     def serialize(self):
         """

--- a/explora/utils/enums.py
+++ b/explora/utils/enums.py
@@ -24,6 +24,18 @@ class DataType(Enum):
     IMAGE = "image"
     TEXT = "text"
 
+class ModelNames(Enum):
+    MNIST = "mnist"
+    NGRAM = "n-gram"
+
+class ModelPaths(Enum):
+    """
+    Enum to enumerate the paths of the default models.
+    """
+    MNIST_PATH = "artifacts/init_mlp_model_with_w.h5"
+    IOS_MNIST_PATH = "artifacts/small_ios_model.h5"
+    NGRAM_PATH = "artifacts/neural_ngram_updatable.mlmodel"
+
 library_types = tuple([library_type.value for library_type in LibraryType])
 color_spaces = tuple([color_space.value for color_space in ColorSpace])
 data_types = tuple([data_type.value for data_type in DataType])
@@ -61,7 +73,11 @@ class ErrorMessages(Enum):
         "are: {}".format(color_spaces) 
     INVALID_IMAGE_DIMS = "Image dimensions must be a tuple of 2 integers."
     MISSING_DATASET_ID = "Dataset ID must be string and is required for iOS " \
-        " libraries!"
+        "libraries!"
     SET_DATASET_ID = "Dataset ID should not be set for non iOS libraries!"
     INVALID_VOCAB_SIZE = "Vocab size must be int and greater than 0!"
+    ONLY_MODEL_NAME_OR_PATH = "Only one of model path and model name must " \
+        "be set!"
+    UNKNOWN_MODEL_NAME = "Unknown model name provided for this library/data " \
+        "type!"
     

--- a/explora/utils/validation.py
+++ b/explora/utils/validation.py
@@ -294,7 +294,7 @@ def valid_session_args(repo_id, model, hyperparameters, \
         max_rounds (int): Maximum number of rounds to train for.
             Defaults to 5.
         library_type (str): The type of library to train with. Must
-            be either `PYTHON` or `JAVASCRIPT` or `IOS`. Defaults to `PYTHON`.
+            be either `PYTHON` or `JAVASCRIPT` or `IOS`.
         checkpoint_frequency (int): Save the model in S3 every
             `checkpoint_frequency` rounds. Defaults to 1.
         data_config (DataConfig): The configuration for the 
@@ -315,16 +315,43 @@ def valid_session_args(repo_id, model, hyperparameters, \
         and valid_dataset_id(library_type, dataset_id)
 
 def _make_mnist_config():
+    """
+    Make config for default MNIST model.
+    
+    Returns:
+        ImageConfig: The config for the default MNIST model.
+    """
     class_labels = [str(i) for i in range(10)]
     color_space = ColorSpace.GRAYSCALE.value
     dims = (28, 28)
     return ImageConfig(class_labels, color_space, dims)
 
 def _make_ngram_config():
+    """
+    Make config for the default n-gram model.
+    
+    Returns:
+        TextConfig: The config for the default n-gram model.
+    """
     vocab_size = 33279
     return TextConfig(vocab_size)
 
 def valid_model_name(model_name, library_type, model_path):
+    """
+    Validate the model name that the user provided. Must correspond to a 
+    default dataset. If the model name is invalid, the first returned value
+    will be `None`.
+    
+    Args:
+        model_name (str): The name corresponding to the default model.
+        library_type (str): The type of library to train with.
+        model_path (str): The model path, must be `None` for the model name
+            to be valid.
+    
+    Returns:
+        (str, DataConfig): Returns the model path to the default model and the
+            corresponding data config, if the library type is `IOS`.
+    """
     if model_path:
         print(ErrorMessages.ONLY_MODEL_NAME_OR_PATH.value)
         return None, None

--- a/explora/utils/validation.py
+++ b/explora/utils/validation.py
@@ -4,8 +4,8 @@ import keras
 import coremltools
 
 from utils.data_config import DataConfig, ImageConfig, TextConfig
-from utils.enums import ErrorMessages, LibraryType, DataType, library_types, \
-    color_spaces, data_types
+from utils.enums import ErrorMessages, LibraryType, DataType, ColorSpace, \
+    ModelNames, ModelPaths, library_types, color_spaces, data_types
 
 
 def valid_repo_id(repo_id):
@@ -198,12 +198,12 @@ def valid_data_config(library_type, data_config):
         bool: True if valid, False otherwise.
     """
     if library_type != LibraryType.IOS.value:
-        if data_config is not None:
+        if data_config:
             print(ErrorMessages.SET_DATA_CONFIG.value)
             return False
         else:
             return True
-    elif data_config == None:
+    elif not data_config:
         print(ErrorMessages.DATA_CONFIG_NOT_SPECIFIED.value)
         return False
     elif not isinstance(data_config, DataConfig):
@@ -313,4 +313,29 @@ def valid_session_args(repo_id, model, hyperparameters, \
         and valid_max_rounds(max_rounds) \
         and valid_checkpoint_frequency(checkpoint_frequency, max_rounds) \
         and valid_dataset_id(library_type, dataset_id)
+
+def _make_mnist_config():
+    class_labels = [str(i) for i in range(10)]
+    color_space = ColorSpace.GRAYSCALE.value
+    dims = (28, 28)
+    return ImageConfig(class_labels, color_space, dims)
+
+def _make_ngram_config():
+    vocab_size = 33279
+    return TextConfig(vocab_size)
+
+def valid_model_name(model_name, library_type, model_path):
+    if model_path:
+        print(ErrorMessages.ONLY_MODEL_NAME_OR_PATH.value)
+        return None, None
+    elif model_name == ModelNames.MNIST.value:
+        if library_type == LibraryType.IOS.value:
+            return ModelPaths.IOS_MNIST_PATH.value, _make_mnist_config()
+        else:
+            return ModelPaths.MNIST_PATH.value, None
+    elif model_name == ModelNames.NGRAM.value:
+        return ModelPaths.NGRAM_PATH.value, _make_ngram_config()
+    else:
+        print(ErrorMessages.UNKNOWN_MODEL_NAME.value)
+        return None, None
     


### PR DESCRIPTION
Add ability for user to specify default models (`mnist` or `n-gram`). This means that they don't need to provide a model path or a data config (for iOS library) anymore.